### PR TITLE
Add setting for minimum on time

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The debug output will contain the following data
     nextStart: number,
     nextEnd: number,
     onState: boolean,
-    noOnStateToday: boolean,
+    operationToday: 'normal' | 'noMidnightWrap' | 'minimumOnTimeNotMet',
 }
 ```
 All the above numbers will be number of minutes since midnight on the day the event happens, except nextStart and nextEnd, which will be the number of minutes until the next event.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "author": {
         "name": "Thomas Bowman Mørch"
     },
-    "version": "0.6.0",
+    "version": "0.7.0",
     "engines": {
         "node": ">=14.0.0"
     },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,3 +11,7 @@ sonar.organization=tbowmogithub
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=./.test_output/coverage/lcov.info
+sonar.sources=src/
+sonar.tests=src/
+sonar.exclusions=**/*.spec.ts
+sonar.test.inclusions=**/*.spec.ts

--- a/src/lib/small-timer-runner.spec.ts
+++ b/src/lib/small-timer-runner.spec.ts
@@ -35,6 +35,7 @@ describe('lib/small-timer-runner', () => {
             onMsgType: 'str',
             wrapMidnight: false,
             debugEnable: false,
+            minimumOnTime: 0,
             id: '',
             type: '',
             name: '',
@@ -46,7 +47,7 @@ describe('lib/small-timer-runner', () => {
             getTimeToNextStartEvent: sinon.stub(),
             getTimeToNextEndEvent: sinon.stub(),
             getOnState: sinon.stub().returns(false),
-            noOnStateToday: sinon.stub().returns(false),
+            operationToday: sinon.stub().returns('normal'),
             debug: sinon.stub().returns({debug: 'this is debug'}),
         }
 
@@ -74,7 +75,7 @@ describe('lib/small-timer-runner', () => {
         const stubs = setupTest()
         stubs.stubbedTimeCalc.getTimeToNextStartEvent.returns(10)
         stubs.stubbedTimeCalc.getTimeToNextEndEvent.returns(20)
-        stubs.stubbedTimeCalc.noOnStateToday.returns(true)
+        stubs.stubbedTimeCalc.operationToday.returns('noMidnightWrap')
 
         new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
 
@@ -82,6 +83,21 @@ describe('lib/small-timer-runner', () => {
             fill: 'yellow',
             shape: 'dot',
             text: 'No action today - off time is before on time',
+        })
+    })
+
+    it('should handle no action today, due to minimum on time not met', () => {
+        const stubs = setupTest()
+        stubs.stubbedTimeCalc.getTimeToNextStartEvent.returns(10)
+        stubs.stubbedTimeCalc.getTimeToNextEndEvent.returns(20)
+        stubs.stubbedTimeCalc.operationToday.returns('minimumOnTimeNotMet')
+
+        new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
+
+        sinon.assert.calledWith(stubs.node.status, {
+            fill: 'yellow',
+            shape: 'dot',
+            text: 'No action today - minimum on time not met',
         })
     })
 

--- a/src/lib/small-timer-runner.spec.ts
+++ b/src/lib/small-timer-runner.spec.ts
@@ -77,13 +77,15 @@ describe('lib/small-timer-runner', () => {
         stubs.stubbedTimeCalc.getTimeToNextEndEvent.returns(20)
         stubs.stubbedTimeCalc.operationToday.returns('noMidnightWrap')
 
-        new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
+        const runner = new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
 
         sinon.assert.calledWith(stubs.node.status, {
             fill: 'yellow',
             shape: 'dot',
             text: 'No action today - off time is before on time',
         })
+
+        runner.onMessage({payload: 'sync', _msgid: ''})
     })
 
     it('should handle no action today, due to minimum on time not met', () => {
@@ -92,13 +94,14 @@ describe('lib/small-timer-runner', () => {
         stubs.stubbedTimeCalc.getTimeToNextEndEvent.returns(20)
         stubs.stubbedTimeCalc.operationToday.returns('minimumOnTimeNotMet')
 
-        new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
+        const runner = new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
 
         sinon.assert.calledWith(stubs.node.status, {
             fill: 'yellow',
             shape: 'dot',
             text: 'No action today - minimum on time not met',
         })
+        runner.onMessage({payload: 'sync', _msgid: ''})
     })
 
     it('should handle temporary on and use timeout to calculate next change', () => {
@@ -154,7 +157,7 @@ describe('lib/small-timer-runner', () => {
         stubs.stubbedTimeCalc.getTimeToNextEndEvent.returns(120.6)
         stubs.stubbedTimeCalc.getOnState.returns(false)
 
-        new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
+        const runner = new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
         sinon.clock.tick(60000)
 
         sinon.assert.calledWithExactly(stubs.status, { fill: 'red', shape: 'dot', text: 'OFF for 00mins 00secs' })
@@ -185,6 +188,8 @@ describe('lib/small-timer-runner', () => {
             payload: 'on-msg',
             topic: 'test-topic',
         })
+
+        runner.onMessage({payload: 'sync', _msgid: ''})
     })
 
     it('should send update together with an debug message when debug is enabled', () => {
@@ -200,7 +205,7 @@ describe('lib/small-timer-runner', () => {
         stubs.stubbedTimeCalc.getTimeToNextEndEvent.returns(120.6)
         stubs.stubbedTimeCalc.getOnState.returns(false)
 
-        new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
+        const runner = new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
 
         sinon.clock.tick(2000)
         sinon.assert.calledWith(stubs.send, [
@@ -216,8 +221,9 @@ describe('lib/small-timer-runner', () => {
             },
             { debug: 'this is debug', override: 'auto', topic: 'debug' },
         ])
-
+        runner.onMessage({payload: 'sync', _msgid: ''})
     })
+
     it('should stop timer, and not advance anything after cleanup has been called', async () => {
         const stubs = setupTest({
             topic: 'test-topic',
@@ -313,8 +319,6 @@ describe('lib/small-timer-runner', () => {
                 payload: '0',
                 topic: 'test-topic',
             })
-
-
         })
 
         it('should output node status when sync message is received, without changing properties', () => {

--- a/src/lib/small-timer-runner.spec.ts
+++ b/src/lib/small-timer-runner.spec.ts
@@ -79,13 +79,13 @@ describe('lib/small-timer-runner', () => {
 
         const runner = new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
 
+        runner.onMessage({payload: 'sync', _msgid: ''})
         sinon.assert.calledWith(stubs.node.status, {
             fill: 'yellow',
             shape: 'dot',
             text: 'No action today - off time is before on time',
         })
 
-        runner.onMessage({payload: 'sync', _msgid: ''})
     })
 
     it('should handle no action today, due to minimum on time not met', () => {
@@ -96,12 +96,12 @@ describe('lib/small-timer-runner', () => {
 
         const runner = new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
 
+        runner.onMessage({payload: 'sync', _msgid: ''})
         sinon.assert.calledWith(stubs.node.status, {
             fill: 'yellow',
             shape: 'dot',
             text: 'No action today - minimum on time not met',
         })
-        runner.onMessage({payload: 'sync', _msgid: ''})
     })
 
     it('should handle temporary on and use timeout to calculate next change', () => {
@@ -158,6 +158,8 @@ describe('lib/small-timer-runner', () => {
         stubs.stubbedTimeCalc.getOnState.returns(false)
 
         const runner = new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
+
+        runner.onMessage({payload: 'sync', _msgid: ''})
         sinon.clock.tick(60000)
 
         sinon.assert.calledWithExactly(stubs.status, { fill: 'red', shape: 'dot', text: 'OFF for 00mins 00secs' })
@@ -188,8 +190,6 @@ describe('lib/small-timer-runner', () => {
             payload: 'on-msg',
             topic: 'test-topic',
         })
-
-        runner.onMessage({payload: 'sync', _msgid: ''})
     })
 
     it('should send update together with an debug message when debug is enabled', () => {
@@ -207,6 +207,7 @@ describe('lib/small-timer-runner', () => {
 
         const runner = new SmallTimerRunner(stubs.position, stubs.configuration, stubs.node)
 
+        runner.onMessage({payload: 'sync', _msgid: ''})
         sinon.clock.tick(2000)
         sinon.assert.calledWith(stubs.send, [
             {
@@ -221,7 +222,6 @@ describe('lib/small-timer-runner', () => {
             },
             { debug: 'this is debug', override: 'auto', topic: 'debug' },
         ])
-        runner.onMessage({payload: 'sync', _msgid: ''})
     })
 
     it('should stop timer, and not advance anything after cleanup has been called', async () => {

--- a/src/lib/small-timer-runner.ts
+++ b/src/lib/small-timer-runner.ts
@@ -1,4 +1,4 @@
-/*eslint complexity: ["error", 12]*/
+/*eslint complexity: ["error", 13]*/
 import {
     Node,
     NodeMessage,
@@ -41,7 +41,6 @@ export class SmallTimerRunner {
     private repeat: boolean
     private onTimeout: number
     private offTimeout: number
-    // private currentTimeout = 0
 
     private timeCalc: TimeCalc
     private debugMode = false
@@ -61,6 +60,7 @@ export class SmallTimerRunner {
             Number(configuration.endTime),
             Number(configuration.startOffset),
             Number(configuration.endOffset),
+            Number(configuration.minimumOnTime),
         )
 
         this.topic = configuration.topic
@@ -205,7 +205,7 @@ export class SmallTimerRunner {
         if (minutes >= 2 || hour) {
             str.push(`${pad(minutes)}mins`)
         }
-        if (minutes<2 && !hour) {
+        if (minutes < 2 && !hour) {
             str.push(`${pad(Math.floor(minutes))}mins`)
             str.push(`${pad(seconds)}secs`)
         }
@@ -219,14 +219,18 @@ export class SmallTimerRunner {
         let fill: NodeStatusFill = 'yellow'
         const text: string[] = []
 
-        const activeToday = !this.timeCalc.noOnStateToday() && (this.isDayOk() || this.currentState)
+        const activeToday = this.timeCalc.operationToday() === 'normal' && (this.isDayOk() || this.currentState)
 
         if (!activeToday) {
             text.push('No action today')
         }
 
-        if (this.timeCalc.noOnStateToday()) {
+        switch (this.timeCalc.operationToday()) {
+        case 'noMidnightWrap':
             text.push('off time is before on time')
+            break
+        case 'minimumOnTimeNotMet':
+            text.push('minimum on time not met')
         }
 
         if (activeToday || this.override !== 'auto') {

--- a/src/lib/time-calculation.spec.ts
+++ b/src/lib/time-calculation.spec.ts
@@ -42,6 +42,7 @@ describe('lib/time-calculation', () => {
             minutes + 120, // 12:00
             0,
             0,
+            0,
         )
 
         sinon.assert.calledWith(stubs.getTimes, currentTime, 10, 10)
@@ -67,15 +68,16 @@ describe('lib/time-calculation', () => {
             5006,
             0,
             0,
+            0,
         )
 
         expect(timeCalc.getOnState()).to.equal(true)
         expect(timeCalc.getTimeToNextEndEvent()).to.equal(180)
         expect(timeCalc.getTimeToNextStartEvent()).to.equal(22 * 60)
-        expect(timeCalc.noOnStateToday()).to.equal(false)
+        expect(timeCalc.operationToday()).to.equal('normal')
     })
 
-    it('should not signal on, if off time is before on time', () => {
+    it('should indicate that on time wraps midnight, if off time is before on time', () => {
         setupTest()
         const currentTime = new Date('2023-01-01 01:00')
         sinon.clock.setSystemTime(currentTime)
@@ -87,12 +89,34 @@ describe('lib/time-calculation', () => {
             5006,
             0,
             0,
+            0,
         )
 
         expect(timeCalc.getOnState()).to.equal(false)
         expect(timeCalc.getTimeToNextEndEvent()).to.equal(180)
         expect(timeCalc.getTimeToNextStartEvent()).to.equal(22 * 60)
-        expect(timeCalc.noOnStateToday()).to.equal(true)
+        expect(timeCalc.operationToday()).to.equal('noMidnightWrap')
+    })
+
+    it('should indicate that on time is lower than minimum on time', () => {
+        setupTest()
+        const currentTime = new Date('2023-01-01 01:00')
+        sinon.clock.setSystemTime(currentTime)
+        const timeCalc = new TimeCalc(
+            10,
+            10,
+            false,
+            45,
+            75,
+            0,
+            0,
+            60,
+        )
+
+        expect(timeCalc.getOnState()).to.equal(false)
+        expect(timeCalc.getTimeToNextEndEvent()).to.equal(15)
+        expect(timeCalc.getTimeToNextStartEvent()).to.equal(1425)
+        expect(timeCalc.operationToday()).to.equal('minimumOnTimeNotMet')
     })
 
     const testData: {
@@ -127,6 +151,7 @@ describe('lib/time-calculation', () => {
                 data.endTime,
                 0,
                 0,
+                0,
             )
 
             expect(timeCalc.getTimeToNextStartEvent()).to.equal(data.expectedStart, 'startEvent')
@@ -140,7 +165,7 @@ describe('lib/time-calculation', () => {
         stubs.getMoonTimes.returns({
             rise: false,
             set: false,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any)
 
         const timeCalc = new TimeCalc(
@@ -149,6 +174,7 @@ describe('lib/time-calculation', () => {
             false,
             5007,
             5008,
+            0,
             0,
             0,
         )
@@ -169,6 +195,7 @@ describe('lib/time-calculation', () => {
             5001,
             0,
             0,
+            0,
         )
 
         expect(timeCalc.setStartEndTime.bind(timeCalc, 6001, 6002))
@@ -184,6 +211,7 @@ describe('lib/time-calculation', () => {
             true,
             5001,
             5002,
+            0,
             0,
             0,
         )
@@ -205,7 +233,7 @@ describe('lib/time-calculation', () => {
             },
             nextEnd: 1320,
             nextStart: 480,
-            noOnStateToday: false,
+            operationToday: 'normal',
 
             actualEnd: 660,
             actualStart: 1260,

--- a/src/nodes/common.ts
+++ b/src/nodes/common.ts
@@ -43,4 +43,5 @@ export interface ISmallTimerProperties extends NodeDef {
     offTimeout: number,
     wrapMidnight: boolean,
     debugEnable: boolean,
+    minimumOnTime: number,
 }

--- a/src/nodes/small-timer.html
+++ b/src/nodes/small-timer.html
@@ -136,6 +136,10 @@
         </div>
     </div>
     <div class="form-row">
+        <label for="node-input-minimumOnTime">Minimum on time</label>
+        <input style="width:80px" type="text" id="node-input-minimumOnTime" placeholder="0">
+    </div>
+    <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tasks"></i> Topic</label>
         <input type="text" id="node-input-topic" placeholder="Topic">
     </div>
@@ -336,6 +340,7 @@
                 onMsg: { value: '1' },
                 onMsgType: { value: 'str' },
                 onTimeout: { value: 1440, required: true },
+                minimumOnTime: { value: 0, required: true},
 
                 offMsg: { value: '0' },
                 offMsgType: { value: 'str' },


### PR DESCRIPTION
Add new option for setting minimum on time. If the calculated on time is below this threshold it will be ignored, can be useful if you are using sun times to calculate on time, and do not want to turn the lights on for just 5 minutes in the fall / spring